### PR TITLE
Fix FastMCP initialization compatibility issue

### DIFF
--- a/src/garth_mcp_server/__init__.py
+++ b/src/garth_mcp_server/__init__.py
@@ -7,7 +7,7 @@ import garth
 from mcp.server.fastmcp import FastMCP
 
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"
 
 server = FastMCP("Garth - Garmin Connect", dependencies=["garth"])
 

--- a/src/garth_mcp_server/__init__.py
+++ b/src/garth_mcp_server/__init__.py
@@ -9,7 +9,7 @@ from mcp.server.fastmcp import FastMCP
 
 __version__ = "0.0.7"
 
-server = FastMCP("Garth - Garmin Connect", dependencies=["garth"], version=__version__)
+server = FastMCP("Garth - Garmin Connect", dependencies=["garth"])
 
 
 def requires_garth_session(func):


### PR DESCRIPTION
## Summary

- Removes the unsupported `version` parameter from FastMCP initialization
- Bumps version to 0.0.8
- Fixes TypeError that prevented the MCP server from starting

## Test plan

- [x] Code passes linting and formatting checks
- [x] Module imports successfully without errors
- [x] All existing functionality preserved

This resolves the breaking change in the FastMCP library API where the `version` parameter is no longer accepted in the constructor.

Fixes #9

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.0.8.

* **Refactor**
  * Simplified server initialization by removing the explicit version parameter; existing behavior remains unchanged for typical usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->