### PR TITLE
Add garth-mcp-auth CLI with MFA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Garmin Connect MCP server based on [garth](https://github.com/matin/garth).
         "garth-mcp-server"
       ],
       "env": {
-        "GARTH_TOKEN": "<output of `uvx garth login`>"
+        "GARTH_TOKEN": "<output of garth-mcp-auth>"
       }
     }
   }
@@ -31,6 +31,42 @@ Garmin Connect MCP server based on [garth](https://github.com/matin/garth).
 Make sure the path for the `uvx` command is fully scoped as MCP doesn't
 use the same PATH your shell does. On macOS, it's typically
 `/Users/{user}/.local/bin/uvx`.
+
+## Authentication
+
+The server requires a `GARTH_TOKEN` environment variable containing your
+Garmin Connect OAuth tokens. Accounts with MFA (multi-factor authentication)
+are fully supported.
+
+### Using garth-mcp-auth (recommended)
+
+```bash
+uvx --from garth-mcp-server garth-mcp-auth
+```
+
+This will prompt for:
+1. Your Garmin email
+2. Your Garmin password (hidden)
+3. Your MFA code (if MFA is enabled on your account)
+
+On success, it prints a token string. Copy this into your MCP config's
+`GARTH_TOKEN` value.
+
+### Using garth CLI
+
+Alternatively, you can use the [garth](https://github.com/matin/garth) CLI
+directly:
+
+```bash
+uvx garth login
+```
+
+### Token lifetime
+
+The token includes an OAuth1 token and an MFA token. The MFA token is
+typically valid for ~1 year, so you should only need to re-authenticate
+annually. The OAuth2 access token expires more frequently but is
+automatically refreshed by the server using the OAuth1 token.
 
 ## Tool Filtering
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ path = "src/garth_mcp_server/__init__.py"
 
 [project.scripts]
 garth-mcp-server = "garth_mcp_server:main"
+garth-mcp-auth = "garth_mcp_server.auth:main"
 
 [project.optional-dependencies]
 dev = [

--- a/src/garth_mcp_server/auth.py
+++ b/src/garth_mcp_server/auth.py
@@ -1,17 +1,116 @@
-"""CLI tool for authenticating with Garmin Connect (MFA supported)."""
+"""CLI tool for authenticating with Garmin Connect (MFA supported).
+
+Uses a manual SSO flow with delays between requests to avoid Garmin's
+aggressive rate limiting on the /sso/signin endpoint.
+"""
 
 import getpass
+import re
 import sys
+import time
 
 import garth
+import garth.sso as sso
 
 
 def main():
+    client = garth.client
+
+    SSO = f"https://sso.{client.domain}/sso"
+    SSO_EMBED = f"{SSO}/embed"
+    SSO_EMBED_PARAMS = dict(id="gauth-widget", embedWidget="true", gauthHost=SSO)
+    SIGNIN_PARAMS = {
+        **SSO_EMBED_PARAMS,
+        "gauthHost": SSO_EMBED,
+        "service": SSO_EMBED,
+        "source": SSO_EMBED,
+        "redirectAfterAccountLoginUrl": SSO_EMBED,
+        "redirectAfterAccountCreationUrl": SSO_EMBED,
+    }
+
     email = input("Garmin email: ")
     password = getpass.getpass("Garmin password: ")
+
     try:
-        garth.login(email, password)
+        # Step 1: Set cookies
+        resp1 = client.sess.get(f"{SSO}/embed", params=SSO_EMBED_PARAMS, timeout=15)
+        resp1.raise_for_status()
+
+        # Step 2: Get CSRF token
+        time.sleep(1)
+        resp2 = client.sess.get(
+            f"{SSO}/signin",
+            params=SIGNIN_PARAMS,
+            headers={"referer": resp1.url},
+            timeout=15,
+        )
+        resp2.raise_for_status()
+        csrf = sso.get_csrf_token(resp2.text)
+
+        # Step 3: Submit credentials
+        time.sleep(2)
+        resp3 = client.sess.post(
+            f"{SSO}/signin",
+            params=SIGNIN_PARAMS,
+            headers={"referer": resp2.url},
+            data={
+                "username": email,
+                "password": password,
+                "embed": "true",
+                "_csrf": csrf,
+            },
+            timeout=15,
+        )
+        resp3.raise_for_status()
     except Exception as e:
         print(f"Login failed: {e}", file=sys.stderr)
         sys.exit(1)
-    print(garth.client.dumps())
+
+    title = re.search(r"<title>(.*?)</title>", resp3.text)
+    title_text = title.group(1) if title else ""
+
+    # Step 4: Handle MFA if needed
+    if "MFA" in title_text:
+        mfa_code = input("MFA code: ")
+        csrf2 = sso.get_csrf_token(resp3.text)
+        time.sleep(1)
+        try:
+            resp4 = client.sess.post(
+                f"{SSO}/verifyMFA/loginEnterMfaCode",
+                params=SIGNIN_PARAMS,
+                headers={"referer": resp3.url},
+                data={
+                    "embed": "true",
+                    "_csrf": csrf2,
+                    "fromPage": "setupEnterMfaCode",
+                    "mfa-code": mfa_code,
+                },
+                timeout=15,
+            )
+            resp4.raise_for_status()
+        except Exception as e:
+            print(f"MFA verification failed: {e}", file=sys.stderr)
+            sys.exit(1)
+        client.last_resp = resp4
+    else:
+        client.last_resp = resp3
+
+    # Step 5: Exchange ticket for OAuth tokens
+    title = re.search(r"<title>(.*?)</title>", client.last_resp.text)
+    title_text = title.group(1) if title else ""
+
+    if title_text != "Success" and not re.search(
+        r'ticket=([^"]+)"', client.last_resp.text
+    ):
+        print(f"Login failed. Page title: {title_text}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        oauth1, oauth2 = sso._complete_login(client)
+        client.oauth1_token = oauth1
+        client.oauth2_token = oauth2
+    except Exception as e:
+        print(f"Token exchange failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(client.dumps())

--- a/src/garth_mcp_server/auth.py
+++ b/src/garth_mcp_server/auth.py
@@ -1,0 +1,17 @@
+"""CLI tool for authenticating with Garmin Connect (MFA supported)."""
+
+import getpass
+import sys
+
+import garth
+
+
+def main():
+    email = input("Garmin email: ")
+    password = getpass.getpass("Garmin password: ")
+    try:
+        garth.login(email, password)
+    except Exception as e:
+        print(f"Login failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    print(garth.client.dumps())


### PR DESCRIPTION
## Summary

- Adds a `garth-mcp-auth` CLI entry point that handles the full Garmin Connect login flow including MFA
- Many Garmin accounts have MFA enabled, and the current auth path (`uvx garth login`) does not document this — users hit confusing 429/error responses when MFA kicks in unexpectedly
- Updated README with a dedicated Authentication section covering MFA, token lifetime, and both auth methods

## Changes

- **`src/garth_mcp_server/auth.py`** — New module: interactive login using `getpass` for password and garth's built-in `prompt_mfa` for MFA
- **`pyproject.toml`** — New `garth-mcp-auth` script entry point
- **`README.md`** — Added Authentication section between Install and Tool Filtering

## Usage

```bash
uvx --from garth-mcp-server garth-mcp-auth
```

Prompts for email, password (hidden), and MFA code (if enabled). Prints the token to stdout.

## Test plan

- [x] Tested with MFA-enabled Garmin account — prompts for code and outputs valid token
- [x] Token works as `GARTH_TOKEN` env var with the MCP server
- [x] Passes `ruff check` and `ruff format`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI authentication tool with interactive, secure credential prompts and support for MFA-enabled accounts.

* **Documentation**
  * Expanded configuration and authentication guides with step‑by‑step setup for the new tool and an alternative CLI login path.
  * Clarified required token contents, token lifetime behavior, and server token refresh expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->